### PR TITLE
EasterEgg, Scanner route, routes back to home page, segment color fix

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -19,8 +19,8 @@ class App extends Component {
   state={
     visible:false,
     leftMenuItems: [
-			{word:"About",link:"#about"},
-			{word:"Founders",link:"#founders"}
+			{word:"About",link:"/#about"},
+			{word:"Founders",link:"/#founders"}
 			]
   }
   handlePusher = () =>{ 
@@ -39,6 +39,7 @@ class App extends Component {
 
           <Sidebar as={Menu} onClick={this.toggleMenu} icon = "labeled" animation='overlay' width='thin' visible={this.state.visible} vertical inverted>
 		      	{this.state.leftMenuItems.map( (item,index) => <Menu.Item key={index} href={item.link}><h3>{item.word}</h3></Menu.Item>)}
+            <Menu.Item key = {2} href={"/scanner"}> <h3>{"Item Scanner"}</h3></Menu.Item>
           </Sidebar>
 
           <Sidebar.Pusher dimmed={this.state.visible} onClick={this.handlePusher}>
@@ -51,7 +52,7 @@ class App extends Component {
             <Switch>
               <Route exact path = "/" component = {Landing} />
               <Route exact path = "/EasterEgg" component = {Page2}/>
-              <Route exact path = "/2" component = {ItemInfo}/>
+              <Route exact path = "/scanner" component = {ItemInfo}/>
             </Switch>
 
             <Footer />

--- a/client/src/components/Footer/Footer.js
+++ b/client/src/components/Footer/Footer.js
@@ -15,7 +15,7 @@ class Footer extends Component {
                     </Grid.Row>
                     </Grid>
                     <div className="copyright">
-                      Copyright &copy; TrashTalks 2018
+                      Copyright &copy;<a href = "/easteregg">.</a> TrashTalks 2018
                     </div>
             </div>
       </div>

--- a/client/src/components/Founders/Founders.css
+++ b/client/src/components/Founders/Founders.css
@@ -3,5 +3,6 @@
 }
 
 #foundersTitleBackground{
-    background-color: #163B53
+    background-color: #163B53;
+    color: white;
 }

--- a/client/src/components/Navbar/Navbar.js
+++ b/client/src/components/Navbar/Navbar.js
@@ -9,8 +9,9 @@ import { Menu, Icon, Responsive, Image} from 'semantic-ui-react';
 // ];
 
 const leftMenuItems = [
-  {word:"About",link:"#about"},
-  {word:"Founders",link:"#founders"},
+  {word:"About", link:"/#about"},
+  {word:"Founders", link:"/#founders"},
+  {word:"Item Scanner", link:"/scanner" }
 ]
 
 const rightMenuItems = [

--- a/client/src/pages/ItemInfo/ItemInfo.css
+++ b/client/src/pages/ItemInfo/ItemInfo.css
@@ -1,11 +1,11 @@
 #infoBinColumns{
     margin:50px;
 }
-#landingTitleBackground{
+  /* #landingTitleBackground{
        background-color: #114C75;   
-     /* background-color:#22859A; */
-     color:white;
-}
+      /* background-color:#22859A;  */
+     /* color:white;
+}   */
 #MatSearchButton, #scannerButton {
        background-color: #308DB7;  
        color:white; 

--- a/client/src/pages/Landing/Landing.css
+++ b/client/src/pages/Landing/Landing.css
@@ -26,7 +26,8 @@ p {
   top: 20%;
 }*/
 #landingTitleBackground{
-    background-color: #163B53
+    background-color: #163B53;
+    color: white;
 }
 
 #isemailModalOpen, #isSlideDeckOpen{

--- a/client/src/pages/Landing/Landing.js
+++ b/client/src/pages/Landing/Landing.js
@@ -205,7 +205,7 @@ class LandingPage extends Component {
 			</Container>
  
 			{/*---------- End of "PageContent" ---------*/}
-			<SlideDeck
+			{/* <SlideDeck
 				modalOpen = {this.state.isSlideDeckOpen}
 				handleClose = {this.SDhandleClose}
 				modalImage = {"TrashTalks_Slide"+(this.state.slideCount+1)+".png"} 
@@ -213,7 +213,7 @@ class LandingPage extends Component {
 				slideBack = {this.slideBackNow}
 				slideForward = {this.slideForwardNow}
 			/>
-			<Button id ="isSlideDeckOpen" onClick = {this.openThisModal} content = "Slide Deck"/>
+			<Button id ="isSlideDeckOpen" onClick = {this.openThisModal} content = "Slide Deck"/> */}
 			</div>
 	    )
 	}


### PR DESCRIPTION
Added the link to the easterEgg.
Added the Scanner page link to the navbar and the sidebar.
Adjusted the "About & Founder" links to go back home.
Adjusted the segments to be the same color; discrepancy was at landing.css & itemInfo.css